### PR TITLE
feat(manifest): adding server_only metafield to manifest

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,10 +1,12 @@
 fx_version 'cerulean'
 game 'common'
+
 lua54 'yes'
+server_only 'yes'
 
 author 'Isekai'
 description 'oxMySql overlay for easier database handling'
-version '1.0.0'
+version '1.0.1'
 
 server_script {
     '@oxmysql/lib/MySQL.lua',


### PR DESCRIPTION
As the script will be working only server side, the usage of the server_only metafield will be a good idea